### PR TITLE
Update transition_to_R.Rmd

### DIFF
--- a/new_pages/transition_to_R.Rmd
+++ b/new_pages/transition_to_R.Rmd
@@ -230,8 +230,7 @@ Set working directory with `libname “folder location”`|Use `setwd(“folder 
 -------------------------------- | ---------------------------------------------
 Use `Proc Import` procedure or using `Data Step Infile` statement.|Use `import()` from **rio** package for almost all filetypes. Specific functions exist as alternatives (see [Import and export])
 Reading in csv files is done by using `Proc Import datafile=”filename.csv” out=work.filename dbms=CSV; run;` OR using [Data Step Infile statement](http://support.sas.com/techsup/technote/ts673.pdf)|Use `import("filename.csv")`
-Reading in xslx files is done by using Proc Import datafile=”filename.xlsx” out=work.filename dbms=xlsx; run;
-OR using [Data Step Infile statement](http://support.sas.com/techsup/technote/ts673.pdf)|Use import("filename.xlsx")
+Reading in xslx files is done by using `Proc Import datafile=”filename.xlsx” out=work.filename dbms=xlsx; run;` OR using [Data Step Infile statement](http://support.sas.com/techsup/technote/ts673.pdf)|Use import("filename.xlsx")
 Browse your data in a new window by opening the Explorer window and select desired library and the dataset|View a dataset in the RStudio source pane using View(dataset). You need to specify your dataset name to the function in R because multiple datasets can be held at the same time. Note capital “V” in this function
 
 **Basic data manipulation**  


### PR DESCRIPTION
Fix formatting of SAS table.
I added backticks to create code text, and more importantly, I remove a space before the "OR" so that the bullet is not split across two lines, and therefore the correct table format is recognized by R Markdown and displayed correctly.